### PR TITLE
CI: add simple golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,162 @@
+---
+# golangci-lint configuration file made by @ccoVeille
+# Source: https://github.com/ccoVeille/golangci-lint-config-examples/
+# Author: @ccoVeille
+# License: MIT
+# Variant: 03-safe
+# Version: v1.1.0
+#
+linters:
+  # some linters are enabled by default
+  # https://golangci-lint.run/usage/linters/
+  #
+  # enable some extra linters
+  enable:
+    # Errcheck is a program for checking for unchecked errors in Go code.
+    - errcheck
+
+    # Linter for Go source code that specializes in simplifying code.
+    - gosimple
+
+    # Vet examines Go source code and reports suspicious constructs.
+    - govet
+
+    # Detects when assignments to existing variables are not used.
+    - ineffassign
+
+    # It's a set of rules from staticcheck. See https://staticcheck.io/
+    - staticcheck
+
+    # Fast, configurable, extensible, flexible, and beautiful linter for Go.
+    # Drop-in replacement of golint.
+    - revive
+
+    # check imports order and makes it always deterministic.
+    - gci
+
+    # make sure to use t.Helper() when needed
+    - thelper
+
+    # mirror suggests rewrites to avoid unnecessary []byte/string conversion
+    - mirror
+
+    # detect the possibility to use variables/constants from the Go standard library.
+    - usestdlibvars
+
+    # Finds commonly misspelled English words.
+    - misspell
+
+    # Checks for duplicate words in the source code.
+    - dupword
+
+    # linter to detect errors invalid key values count
+    - loggercheck
+
+    # detects nested contexts in loops or function literals
+    - fatcontext
+
+linters-settings:
+  gci:  # define the section orders for imports
+    sections:
+      # Standard section: captures all standard packages.
+      - standard
+      # Default section: catchall that is not standard or custom
+      - default
+      # linters that related to local tool, so they should be separated
+      - localmodule
+
+  revive:
+    rules:
+      # these are the default revive rules
+      # you can remove the whole "rules" node if you want
+      # BUT
+      # ! /!\ they all need to be present when you want to add more rules than the default ones
+      # otherwise, you won't have the default rules, but only the ones you define in the "rules" node
+
+      # Blank import should be only in a main or test package, or have a comment justifying it.
+      - name: blank-imports
+
+      # context.Context() should be the first parameter of a function when provided as argument.
+      - name: context-as-argument
+        arguments:
+          - allowTypesBefore: "*testing.T"
+
+      # Basic types should not be used as a key in `context.WithValue`
+      - name: context-keys-type
+
+      # Importing with `.` makes the programs much harder to understand
+      - name: dot-imports
+
+      # Empty blocks make code less readable and could be a symptom of a bug or unfinished refactoring.
+      - name: empty-block
+
+      # for better readability, variables of type `error` must be named with the prefix `err`.
+      - name: error-naming
+
+      # for better readability, the errors should be last in the list of returned values by a function.
+      - name: error-return
+
+      # for better readability, error messages should not be capitalized or end with punctuation or a newline.
+      - name: error-strings
+
+      # report when replacing `errors.New(fmt.Sprintf())` with `fmt.Errorf()` is possible
+      - name: errorf
+
+      # incrementing an integer variable by 1 is recommended to be done using the `++` operator
+      - name: increment-decrement
+
+      # highlights redundant else-blocks that can be eliminated from the code
+      - name: indent-error-flow
+
+      # This rule suggests a shorter way of writing ranges that do not use the second value.
+      - name: range
+
+      # receiver names in a method should reflect the struct name (p for Person, for example)
+      - name: receiver-naming
+
+      # redefining built in names (true, false, append, make) can lead to bugs very difficult to detect.
+      - name: redefines-builtin-id
+
+      # redundant else-blocks that can be eliminated from the code.
+      - name: superfluous-else
+
+      # prevent confusing name for variables when using `time` package
+      - name: time-naming
+
+      # warns when an exported function or method returns a value of an un-exported type.
+      - name: unexported-return
+
+      # spots and proposes to remove unreachable code. also helps to spot errors
+      - name: unreachable-code
+
+      # Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
+      - name: unused-parameter
+
+      # report when a variable declaration can be simplified
+      - name: var-declaration
+
+      # warns when initialism, variable or package naming conventions are not followed.
+      - name: var-naming
+
+  dupword:
+    # Keywords used to ignore detection.
+    # Default: []
+    ignore: []
+    #  - "blah" # this will accept "blah blah …" as a valid duplicate word
+
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+    # Default ("") is to use a neutral variety of English.
+    locale: US
+
+    # List of words to ignore
+    # among the one defined in https://github.com/golangci/misspell/blob/master/words.go
+    ignore-words: []
+    #  - valor
+    #  - and
+
+    # Extra word corrections.
+    extra-words: []
+    #  - typo: "whattever"
+    #    correction: "whatever"


### PR DESCRIPTION
The configuration is based on the default configuration provided by ccoVeille

https://github.com/ccoVeille/golangci-lint-config-examples/tree/main/03-safe
